### PR TITLE
Fix problem with power < 2 multivariate monomials

### DIFF
--- a/src/bound_propagation/polynomial.py
+++ b/src/bound_propagation/polynomial.py
@@ -313,6 +313,7 @@ class MultivariateMonomial(nn.Sequential):
         if factors:
             modules = [
                 Parallel(Select(linear_terms), UnivariateMonomial(factors)),
+                Parallel(*[self.construct_mul(monomial_index) for monomial_index in monomial_indices])
             ]
         else: 
             modules = [

--- a/src/bound_propagation/polynomial.py
+++ b/src/bound_propagation/polynomial.py
@@ -310,10 +310,16 @@ class MultivariateMonomial(nn.Sequential):
 
             monomial_indices.append(monomial_index)
 
-        super().__init__(
-            Parallel(Select(linear_terms), UnivariateMonomial(factors)),
-            Parallel(*[self.construct_mul(monomial_index) for monomial_index in monomial_indices])
-        )
+        if factors:
+            modules = [
+                Parallel(Select(linear_terms), UnivariateMonomial(factors)),
+            ]
+        else: 
+            modules = [
+                Parallel(*[self.construct_mul(monomial_index) for monomial_index in monomial_indices])
+            ]
+
+        super().__init__(*modules)
 
     def construct_mul(self, monomial_index):
         module = Select(monomial_index[0])


### PR DESCRIPTION
Hey @Zinoex, 

With @EduardoFMDCosta we're using `bp.MultivariateMonomial(monomials)` to describe Dubin's car dynamics with v and w as variables, with 
```python
monomials = [
  [(0, 1)],           # x0 = x
  [(1, 1)],           # x1 = y
  [(3, 1)],           # x3 = theta + h * w
  [(2, 1), (4, 1)],   # x2 * x4 = v * h * cos(theta)
  [(2, 1), (5, 1)],   # x2 * x5 = v * h * sin(theta)
]
```

I get the error
```
File .venv/lib/python3.13/site-packages/bound_propagation/reshape.py", line 25, in forward
    return x[..., self.indices]
           ~^^^^^^^^^^^^^^^^^^^
IndexError: tensors used as indices must be long, int, byte or bool tensors
```
when using such layer because `factors` is empty (there are no monomials with `power >= 2`). With this fix, this isn't a problem anymore. 

Maybe this function was only meant to be used with powers >= 2. In such case feel free to ignore this PR. :) 